### PR TITLE
Add defines based on installed physics packages

### DIFF
--- a/Runtime/2D/BoxCast.cs
+++ b/Runtime/2D/BoxCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -274,3 +275,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/BoxCastAll.cs
+++ b/Runtime/2D/BoxCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -149,3 +150,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/BoxCastNonAlloc.cs
+++ b/Runtime/2D/BoxCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -153,3 +154,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CapsuleCast.cs
+++ b/Runtime/2D/CapsuleCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -301,3 +302,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CapsuleCastAll.cs
+++ b/Runtime/2D/CapsuleCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -157,3 +158,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CapsuleCastNonAlloc.cs
+++ b/Runtime/2D/CapsuleCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -159,3 +160,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CircleCast.cs
+++ b/Runtime/2D/CircleCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -265,3 +266,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CircleCastAll.cs
+++ b/Runtime/2D/CircleCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -143,3 +144,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/CircleCastNonAlloc.cs
+++ b/Runtime/2D/CircleCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -147,3 +148,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/ClosestPoint.cs
+++ b/Runtime/2D/ClosestPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 
@@ -106,3 +107,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/Distance.cs
+++ b/Runtime/2D/Distance.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 
@@ -64,3 +65,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/GetContacts.cs
+++ b/Runtime/2D/GetContacts.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 
@@ -312,3 +313,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/GetRayIntersection.cs
+++ b/Runtime/2D/GetRayIntersection.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 using UnityEngine.Internal;
@@ -86,3 +87,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/GetRayIntersectionAll.cs
+++ b/Runtime/2D/GetRayIntersectionAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -74,3 +75,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/GetRayIntersectionNonAlloc.cs
+++ b/Runtime/2D/GetRayIntersectionNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -76,3 +77,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/IsTouching.cs
+++ b/Runtime/2D/IsTouching.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -95,3 +96,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/IsTouchingLayers.cs
+++ b/Runtime/2D/IsTouchingLayers.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 using UnityEngine.Internal;
@@ -51,3 +52,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/LineCast.cs
+++ b/Runtime/2D/LineCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 using UnityEngine.Internal;
@@ -186,3 +187,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/LineCastAll.cs
+++ b/Runtime/2D/LineCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -105,3 +106,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/LineCastNonAlloc.cs
+++ b/Runtime/2D/LineCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -111,3 +112,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapArea.cs
+++ b/Runtime/2D/OverlapArea.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -171,3 +172,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapAreaAll.cs
+++ b/Runtime/2D/OverlapAreaAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -104,3 +105,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapAreaNonAlloc.cs
+++ b/Runtime/2D/OverlapAreaNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -111,3 +112,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapBox.cs
+++ b/Runtime/2D/OverlapBox.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -182,3 +183,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapBoxAll.cs
+++ b/Runtime/2D/OverlapBoxAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -112,3 +113,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapBoxNonAlloc.cs
+++ b/Runtime/2D/OverlapBoxNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -119,3 +120,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCapsule.cs
+++ b/Runtime/2D/OverlapCapsule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -201,3 +202,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCapsuleAll.cs
+++ b/Runtime/2D/OverlapCapsuleAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -124,3 +125,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCapsuleNonAlloc.cs
+++ b/Runtime/2D/OverlapCapsuleNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -124,3 +125,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCircle.cs
+++ b/Runtime/2D/OverlapCircle.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -168,3 +169,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCircleAll.cs
+++ b/Runtime/2D/OverlapCircleAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -108,3 +109,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCircleNonAlloc.cs
+++ b/Runtime/2D/OverlapCircleNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -110,3 +111,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapCollider.cs
+++ b/Runtime/2D/OverlapCollider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -94,3 +95,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapPoint.cs
+++ b/Runtime/2D/OverlapPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -157,3 +158,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapPointAll.cs
+++ b/Runtime/2D/OverlapPointAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -102,3 +103,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/OverlapPointNonAlloc.cs
+++ b/Runtime/2D/OverlapPointNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -104,3 +105,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/Raycast.cs
+++ b/Runtime/2D/Raycast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
@@ -229,3 +230,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/RaycastAll.cs
+++ b/Runtime/2D/RaycastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -135,3 +136,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/RaycastNonAlloc.cs
+++ b/Runtime/2D/RaycastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -137,3 +138,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/2D/Utils.cs
+++ b/Runtime/2D/Utils.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if RAYCASTVISUALIZATION_2D_PHYSICS
+using UnityEngine;
 
 namespace Nomnom.RaycastVisualization {
   public static partial class VisualPhysics2D {
@@ -15,3 +16,4 @@ namespace Nomnom.RaycastVisualization {
     }
   }
 }
+#endif

--- a/Runtime/3D/BoxCast.cs
+++ b/Runtime/3D/BoxCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using Nomnom.RaycastVisualization.Shapes;
 using UnityEngine;
 using UnityEngine.Internal;
@@ -191,3 +192,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/BoxCastAll.cs
+++ b/Runtime/3D/BoxCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -110,3 +111,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/BoxCastNonAlloc.cs
+++ b/Runtime/3D/BoxCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -115,3 +116,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CapsuleCast.cs
+++ b/Runtime/3D/CapsuleCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -153,3 +154,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CapsuleCastAll.cs
+++ b/Runtime/3D/CapsuleCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -96,3 +97,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CapsuleCastNonAlloc.cs
+++ b/Runtime/3D/CapsuleCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -102,3 +103,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CheckBox.cs
+++ b/Runtime/3D/CheckBox.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -64,3 +65,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CheckCapsule.cs
+++ b/Runtime/3D/CheckCapsule.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -49,3 +50,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/CheckSphere.cs
+++ b/Runtime/3D/CheckSphere.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -47,3 +48,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/ClosestPoint.cs
+++ b/Runtime/3D/ClosestPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Nomnom.RaycastVisualization {
@@ -23,3 +24,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/ComputePenetration.cs
+++ b/Runtime/3D/ComputePenetration.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Nomnom.RaycastVisualization {
@@ -31,3 +32,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/Linecast.cs
+++ b/Runtime/3D/Linecast.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -78,3 +79,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapBox.cs
+++ b/Runtime/3D/OverlapBox.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -82,3 +83,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapBoxNonAlloc.cs
+++ b/Runtime/3D/OverlapBoxNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -88,3 +89,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapCapsule.cs
+++ b/Runtime/3D/OverlapCapsule.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -60,3 +61,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapCapsuleNonAlloc.cs
+++ b/Runtime/3D/OverlapCapsuleNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -79,3 +80,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapSphere.cs
+++ b/Runtime/3D/OverlapSphere.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -64,3 +65,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/OverlapSphereNonAlloc.cs
+++ b/Runtime/3D/OverlapSphereNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -71,3 +72,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/Raycast.cs
+++ b/Runtime/3D/Raycast.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -255,3 +256,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/RaycastAll.cs
+++ b/Runtime/3D/RaycastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -102,3 +103,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/RaycastNonAlloc.cs
+++ b/Runtime/3D/RaycastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -145,3 +146,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/SphereCast.cs
+++ b/Runtime/3D/SphereCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -184,3 +185,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/SphereCastAll.cs
+++ b/Runtime/3D/SphereCastAll.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -145,3 +146,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/3D/SphereCastNonAlloc.cs
+++ b/Runtime/3D/SphereCastNonAlloc.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if RAYCASTVISUALIZATION_3D_PHYSICS
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Internal;
 
@@ -161,3 +162,4 @@ namespace Nomnom.RaycastVisualization {
 		}
 	}
 }
+#endif

--- a/Runtime/Shapes/Capsule.cs
+++ b/Runtime/Shapes/Capsule.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+﻿#if UNITY_EDITOR && RAYCASTVISUALIZATION_3D_PHYSICS
 using System.Runtime.CompilerServices;
 using UnityEngine;
 

--- a/Runtime/Shapes/Filter2D.cs
+++ b/Runtime/Shapes/Filter2D.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+﻿#if UNITY_EDITOR && RAYCASTVISUALIZATION_2D_PHYSICS
 using System.Runtime.CompilerServices;
 using UnityEngine;
 

--- a/Runtime/VisualUtils.cs
+++ b/Runtime/VisualUtils.cs
@@ -169,6 +169,7 @@ namespace Nomnom.RaycastVisualization {
 #endif
 		}
 
+#if RAYCASTVISUALIZATION_3D_PHYSICS
 		public static void DrawCapsuleNoColor(in Vector3 point1, in Vector3 point2, in Vector3 direction, in float radius,
 			in float maxDistance,
 			in RaycastHit hit, in bool didHit) {
@@ -235,6 +236,7 @@ namespace Nomnom.RaycastVisualization {
 			}
 #endif
 		}
+#endif
 
 		public static void DrawCube(in Vector3 center, in Vector3 size, in Quaternion rotation, in Color color) {
 #if UNITY_EDITOR

--- a/Runtime/com.nomnom.raycast-visualization.asmdef
+++ b/Runtime/com.nomnom.raycast-visualization.asmdef
@@ -9,6 +9,17 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "RAYCASTVISUALIZATION_3D_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "RAYCASTVISUALIZATION_2D_PHYSICS"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Fixes compilation errors if you're not using any physics packages. For example, if you're making a 3D game, you probably don't need the 2D module. But if you disable it, you get compilation errors due to Physics 2D missing. This PR fixes this for both Physics 2D and 3D. 

I just added two version defines by checking the installed packages, and if they are installed, add a compilation define for each module.