### PR TITLE
Fix missing IMGUI package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "methods",
     "visuals"
   ],
+  "dependencies": {
+    "com.unity.modules.imgui": "1.0.0"
+  },
   "author": {
     "name": "Andrew Burke",
     "email": "nomnomab1@gmail.com"


### PR DESCRIPTION
This is a small quality of life fix that just makes sure the IMGUI module is installed. It's required due to the use of `GUIContent` in VisualPhysicsSettings.